### PR TITLE
Feature json api compound document

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Demonstrations of each of these items can be found in the app
 * API Application
   * We only need an API, use `ActionController::API` for lighter weight API code
   * Use `/api` namespace
+  * JSON API for API standardization
+    * Sparse Fieldsets
+    * Compound Documents
   * Status codes
   * `201` on created
   * `422` on error

--- a/app/controllers/api/trips_controller.rb
+++ b/app/controllers/api/trips_controller.rb
@@ -24,7 +24,30 @@ class Api::TripsController < ApiController
     end
   end
 
+  # Get more details about a single trip
+  # TODO add JSON API mime type
+  def details
+    options = {}
+    # include=driver
+    # fields[driver]=average_rating
+    if params[:fields]
+      driver_fields = params[:fields].permit(:driver).to_h.
+        inject({}) { |h, (k,v)| h[k.to_sym] = v.split(",").map(&:to_sym); h }
+      options.merge!(fields: driver_fields)
+    end
+
+    # multiple associated resources are comma-separated
+    if params[:include]
+      options[:include] = params[:include].split(",").map(&:to_sym)
+    end
+
+    @trip = Trip.includes(:driver).find_by(id: params[:id])
+
+    render json: TripSerializer.new(@trip, options).serializable_hash
+  end
+
   # TODO authentication
+  # TODO add JSON API mime type
   def my
     @trips = Trip.completed.
       includes(:driver, {trip_request: :rider}).

--- a/app/models/driver.rb
+++ b/app/models/driver.rb
@@ -1,3 +1,7 @@
 class Driver < User
   has_many :trips
+
+  def average_rating
+    trips.average(:rating)
+  end
 end

--- a/app/serializers/driver_serializer.rb
+++ b/app/serializers/driver_serializer.rb
@@ -1,0 +1,14 @@
+class DriverSerializer
+  include FastJsonapi::ObjectSerializer
+
+  extend ActionView::Helpers::NumberHelper
+
+  attribute :display_name
+
+  attribute :average_rating do |driver|
+    number_to_percentage(
+      driver.average_rating,
+      precision: 2
+    )
+  end
+end

--- a/app/serializers/trip_serializer.rb
+++ b/app/serializers/trip_serializer.rb
@@ -8,4 +8,6 @@ class TripSerializer
   attribute :driver_name do |trip|
     trip.driver.display_name
   end
+
+  belongs_to :driver
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
       collection do
         get :my
       end
+      member do
+        get :details
+      end
     end
     resources :trip_requests, only: [:create]
   end


### PR DESCRIPTION
Add demo of compound document

Combine compound document and sparse fieldsets
functionality 

This demo fetches details about a single trip,
and the driver details can be included to skip
having to make a second API request for the driver
details.

Additionally, the fields on the driver can be limited.
Currently the serialize has 2 fields, display_name
and average_rating. There are controller tests
that demonstrate requesting all the fields for the
driver, and only the average_rating for the driver.

The driver association was set up on the trip
serializer, and a driver serializer was added.

A new route was added for a single trip, although
compound document support could be added to the
“my trips” API. This single trip API duplicates
the #show endpoint, but that was set up for demonstrating
http caching, so I left it.


https://github.com/Netflix/fast_jsonapi#compound-document

https://jsonapi.org/format/#document-compound-documents