### PR TITLE
Update pg_query dep from `>= 2` to `~> 4.2`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'fx' # manage DB Functions
 gem 'scenic' # manage DB Views
 gem 'whenever', require: false # manage scheduled jobs
 gem 'prosopite' # identify N+1 queries
-gem 'pg_query', '>= 2'
+gem 'pg_query', '~> 4.2'
 gem 'pg_search'
 gem 'pgslice', git: 'git@github.com:andyatkinson/pgslice.git'
 gem 'fast_count', git: 'https://github.com/fatkodima/fast_count.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,7 +154,7 @@ GEM
     geocoder (1.8.1)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    google-protobuf (3.21.12)
+    google-protobuf (3.24.2-x86_64-linux)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     importmap-rails (1.2.1)
@@ -193,8 +193,8 @@ GEM
     nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
     pg (1.4.5)
-    pg_query (2.2.1)
-      google-protobuf (>= 3.19.2)
+    pg_query (4.2.3)
+      google-protobuf (>= 3.22.3)
     pg_search (2.3.6)
       activerecord (>= 5.2)
       activesupport (>= 5.2)
@@ -298,7 +298,7 @@ DEPENDENCIES
   json
   jwt
   pg
-  pg_query (>= 2)
+  pg_query (~> 4.2)
   pg_search
   pghero!
   pgslice!


### PR DESCRIPTION
`Gemfile.lock` updates are a consequence of running `bundle install`; tests pass via `bin/rails test`