### PR TITLE
Configure ci postgres to use root user with TRUST 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,9 +17,9 @@ jobs:
       - image: cimg/ruby:3.2.0
       - image: cimg/postgres:13.6
         environment:
-          POSTGRES_USER: postgres
+          POSTGRES_USER: root
           POSTGRES_DB: rideshare_test
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
     environment:
       BUNDLE_JOBS: "3"
       BUNDLE_RETRY: "3"
@@ -27,7 +27,7 @@ jobs:
       PGUSER: root
       PGPASSWORD: ""
       RAILS_ENV: test
-      PGSLICE_URL: "postgres://postgres:postgres@localhost:5432/rideshare_test"
+      PGSLICE_URL: "postgres://root@localhost:5432/rideshare_test"
     steps:
       - checkout
       - ruby/install-deps

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter: postgresql
   username: postgres
-  password: postgres
+  password:
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
@@ -17,6 +17,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
+  username: root
   host: localhost
   database: rideshare_test
 


### PR DESCRIPTION
From discussion in #93 , given that `docker-compose*` environments aren't intended to be used and are a sort of deprecated vestige in the repository, switch back to `root` user, with TRUST authentication.