### PR TITLE
Add more PostgreSQL timeout values, docs, to help learners/as documentation

### DIFF
--- a/config/database-multiple.sample.yml
+++ b/config/database-multiple.sample.yml
@@ -1,7 +1,6 @@
 default: &default
   adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
   variables:
     statement_timeout: 5000
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,8 +1,18 @@
+#
+# Configuring Active Record:
+# <https://guides.rubyonrails.org/configuring.html#configuring-active-record>
+#
+# Database Connection Control Functions
+# <https://www.postgresql.org/docs/current/libpq-connect.html>
+#
 default: &default
   adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
   schema_search_path: rideshare
+  prepared_statements: true # enabled by default
+  advisory_locks: true # enabled by default
+  # Optional (PostgreSQL):
+  # checkout_timeout, read_timeout
 
 test:
   <<: *default
@@ -13,4 +23,10 @@ development:
   url: <%= ENV['DATABASE_URL'] %>
   database: rideshare_development
   variables:
-    statement_timeout: 5000
+    # https://www.postgresql.org/docs/current/runtime-config-client.html
+    statement_timeout: 5000 # seconds, set at client level
+    idle_in_transaction_session_timeout: 300000 # milliseconds
+    # PostgreSQL params:
+    # idle_timeout
+    # lock_timeout
+    # idle_session_timeout


### PR DESCRIPTION
@danielabar asked about `timeout` and this prompted exploring the rails
source code. This seems to only be for sqlite, so maybe it was leftover
from originally generating this config file for sqlite. PostgreSQL and
MySQL have different parameters they support.

This is all about PostgreSQL, I added the params related to PostgreSQL
and Rails Guide and PostgreSQL documentation links.

The things we're protecting:

- Max allowed time to check out a connection from the AR pool
- Max time to wait before giving up, when all connections are busy

On PostgreSQL side we can protect against:

- Statements that would otherwise run forever in error, they should be
  canceled
- Statements that open a transaction and then are idle for too long