### PR TITLE
Create pg_stat_statements extension after creating schema

### DIFF
--- a/db/create_schema.sql
+++ b/db/create_schema.sql
@@ -9,3 +9,5 @@ RESET ROLE;
 ALTER ROLE owner SET search_path TO rideshare;
 
 SET search_path TO rideshare;
+
+CREATE EXTENSION pg_stat_statements WITH SCHEMA rideshare;


### PR DESCRIPTION
I kept having unusual results when following the instruction on page 38 of the book.

``` sql
SELECT
  attname,
  n_distinct,
  most_common_vals
FROM
  pg_stats
WHERE
  tablename = 'users'
  AND attname = 'first_name';
-[ RECORD 1 ]----+-----------
attname          | first_name
n_distinct       | -1
most_common_vals |
```

This is __after__ running both the `bin/rails data_generators:generate_all` task and `db/scripts/bulk_load.sh`.

What I eventually figured out is that `pg_stat_statements` extension is not persistent through the `db:reset` custom task. Because I had reset the database at some point, I was not getting any of the stats.

Furthermore, even if I install `pg_stat_statements` after generating data and run `analyze` or `vacuum (full, analyze)` this doesn't collect the `most_common_vals` information, which is only populated during `INSERT` and `UPDATE` statements.

To alleviate this headache for myself and future readers, I added the extension to the database setup script. Yes, this does assume that the user has set `shared_preload_libraries = 'pg_stat_statements'` for their postgres distribution, so maybe this is not desirable from the author's perspective.