### PR TITLE
Add `arm64-darwin-22` platform ot Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -303,6 +303,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-22
   arm64-darwin-23
   x86_64-darwin-20
   x86_64-darwin-21


### PR DESCRIPTION
This line appears after running `bundle install` on m1 MBA. It shouldn't affect any other platform users in any way.