### PR TITLE
Raise statement_timeout further

### DIFF
--- a/db/scripts/bulk_load.sh
+++ b/db/scripts/bulk_load.sh
@@ -50,8 +50,8 @@ if [ -z "$DATABASE_URL" ]; then
     exit 1
 fi
 
-echo "Creating batch of rideshare.users rows, raising statement_timeout to 600000 (10 minutes)..."
-psql $DATABASE_URL -c "SET statement_timeout = 600000; $query";
+echo "Creating batch of rideshare.users rows, raising statement_timeout to 30min"
+psql $DATABASE_URL -c "SET statement_timeout = '30min'; $query";
 
 echo "ANALYZE rideshare.users"
 psql $DATABASE_URL -c "ANALYZE rideshare.users";

--- a/db/scripts/bulk_load_extended.sh
+++ b/db/scripts/bulk_load_extended.sh
@@ -38,8 +38,8 @@ if [ -z "$DATABASE_URL" ]; then
     exit 1
 fi
 
-echo "Raising statement_timeout to 600000 (10 minutes), running $query..."
-psql $DATABASE_URL -c "SET statement_timeout = 600000; $query";
+echo "Raising statement_timeout to 30 minutes, running $query..."
+psql $DATABASE_URL -c "SET statement_timeout = '30min'; $query";
 psql $DATABASE_URL -c "ANALYZE (VERBOSE) rideshare.trip_requests";
 
 
@@ -70,7 +70,7 @@ SELECT
   (SELECT (RANDOM()*5)::INTEGER),
   (SELECT (timestamp - INTERVAL '1 day') from last_90_days),
   NOW()
-FROM GENERATE_SERIES(1, 1_000_000) seq;
+FROM GENERATE_SERIES(1, 10_000_000) seq;
 "
 
 if [ -z "$DATABASE_URL" ]; then
@@ -79,8 +79,8 @@ if [ -z "$DATABASE_URL" ]; then
     exit 1
 fi
 
-echo "Raising statement_timeout to 600000 (10 minutes), running $query..."
-psql $DATABASE_URL -c "SET statement_timeout = 600000; $query";
+echo "Raising statement_timeout to 30 minutes, running $query..."
+psql $DATABASE_URL -c "SET statement_timeout = '30min'; $query";
 psql $DATABASE_URL -c "ANALYZE (VERBOSE) rideshare.trips";
 
 echo "Estimated counts:"


### PR DESCRIPTION
For bulk loading 10 million records at a time, set a statement timeout
of 30 minutes so that there's plenty of time for this operation to
complete

This was tested on Postgres 16 on a MacBook Pro M1 with SSD
