### PR TITLE
Add `arm64-darwin-24` to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,6 +316,7 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22


### PR DESCRIPTION
### Why

I ran `bundle install` on a Macbook Air M2, and it added this platform to the `Gemfile.lock`.

### What

Add `arm64-darwin-24` to `Gemfile.lock`.