### PR TITLE
Update pg_query to fix installation on Mac OS ARM

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'fast_jsonapi', '~> 1.5'
 gem 'geocoder', '~> 1.8'
 gem 'jwt', '~> 2.7'
 gem 'pg', '~> 1.5'
-gem 'pg_query', '~> 5.1'
+gem 'pg_query', '~> 6.1'
 gem 'pg_search', '~> 2.3'
 gem 'prosopite', '~> 1.4' # identify N+1 queries
 gem 'puma', '~> 6.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,16 +140,16 @@ GEM
       csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (4.31.1-aarch64-linux-gnu)
+    google-protobuf (4.32.0-aarch64-linux-gnu)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-arm64-darwin)
+    google-protobuf (4.32.0-arm64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-x86_64-darwin)
+    google-protobuf (4.32.0-x86_64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.31.1-x86_64-linux-gnu)
+    google-protobuf (4.32.0-x86_64-linux-gnu)
       bigdecimal
       rake (>= 13)
     i18n (1.14.7)
@@ -207,8 +207,8 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.9)
-    pg_query (5.1.0)
-      google-protobuf (>= 3.22.3)
+    pg_query (6.1.0)
+      google-protobuf (>= 3.25.3)
     pg_search (2.3.7)
       activerecord (>= 6.1)
       activesupport (>= 6.1)
@@ -373,7 +373,7 @@ DEPENDENCIES
   json
   jwt (~> 2.7)
   pg (~> 1.5)
-  pg_query (~> 5.1)
+  pg_query (~> 6.1)
   pg_search (~> 2.3)
   pghero!
   pgslice!


### PR DESCRIPTION
Hello :)

I had troubles installing pg_query on my Mac with M3 ARM cpu. Found out this closed issue:

https://github.com/pganalyze/pg_query/issues/327

Updated pg_query to 6.1

I hope this is fine, even if it's a major change. I'm still at the beginning of the book so I don't know it :)