### PR TITLE
Add reindex shell script with tmux and psql

### DIFF
--- a/db/db_reindex_batch.sh
+++ b/db/db_reindex_batch.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Dependencies:
+# - tmux (detach "ctrl-b" and re-attach e.g. "tmux attach -t db_reindex")
+# - export DATABASE_URL (must be set) to be set to DB connection string URL
+# - reindex_batch.sql to have the reindex commands
+# - monitor progress: https://github.com/andyatkinson/pg_scripts/blob/main/concurrent_index_build_progress.sql
+# - run monitor SQL above repeatly, every 1s: "psql> \watch 1"
+
+# Configuration
+SESSION_NAME="db_reindex"
+SQL_FILE="reindex_batch.sql"
+
+# Create new tmux session and detach from it
+tmux new-session -d -s $SESSION_NAME
+
+# Send the psql command to the tmux session and execute it
+tmux send-keys -t $SESSION_NAME "psql -d $DATABASE_URL -f $SQL_FILE" C-m
+
+# List the sessions
+tmux ls
+
+# Reattach later on
+echo
+echo "Reindexing is now taking place inside session '$SESSION_NAME' and you're detached from it"
+echo
+echo "To re-attach, find the session name w/ 'tmux ls'. Hint: 'tmux attach -t $SESSION_NAME'"
+echo
+echo "To monitor concurrent index build progress: https://github.com/andyatkinson/pg_scripts/blob/main/concurrent_index_build_progress.sql"
+echo

--- a/db/reindex_batch.sql
+++ b/db/reindex_batch.sql
@@ -1,0 +1,14 @@
+set statement_timeout='2h'; -- or whatever max is needed to perform the longest one of these
+
+reindex (verbose) index concurrently trips_pkey;
+reindex (verbose) index index_trips_on_driver_id;
+reindex (verbose) index index_trips_on_rating;
+reindex (verbose) index index_trips_on_trip_request_id;
+
+reindex (verbose) index trip_requests_pkey;
+reindex (verbose) index index_trip_requests_on_end_location_id;
+reindex (verbose) index index_trip_requests_on_rider_id;
+reindex (verbose) index index_trip_requests_on_start_location_id;
+
+-- users table has 3 indexes, reindex all indexes for table
+reindex (verbose) table concurrently users;


### PR DESCRIPTION
Invoke manual REINDEX commands, either specific indexes or all indexes
for a table

Use "VERBOSE" and "CONCURRENTLY" options

Set a high statement_timeout to allow enough time for a REINDEX
operation to finish

Add a link to a query to monitor concurrent index build progress
