### PR TITLE
Require PostgreSQL 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ brew install rbenv
 ```
 
 ## PostgreSQL
-PostgreSQL 16 or greater is required. Installation may be via Homebrew, although the recommended method is [Postgres.app](https://postgresapp.com)
+PostgreSQL 18 or greater is required. `db/structure.sql` sets `transaction_timeout`, which was added in PostgreSQL 17, so earlier versions fail to load the schema. Installation may be via Homebrew, although the recommended method is [Postgres.app](https://postgresapp.com)
 
 ### PostgresApp
-- Once installed, from the Menu Bar app, choose "Open Postgres" then click the "+" icon to create a new PostgreSQL 16 server
+- Once installed, from the Menu Bar app, choose "Open Postgres" then click the "+" icon to create a new PostgreSQL 18 server
 
 
 ## Ruby
@@ -68,7 +68,7 @@ bundle install
 ```
 
 ## Rideshare Development Database
-⚠️  This scripts expects PostgreSQL version 16. If you see syntax errors with underscore numbers like `10_000`, it's probably from using an older version that doesn't support that number style.
+⚠️  This scripts expects PostgreSQL version 18. If you see syntax errors with underscore numbers like `10_000`, it's probably from using an older version that doesn't support that number style.
 
 ⚠️   Normally in Ruby on Rails applications, you'd run `bin/rails db:create` to create the development and test databases. Don't do that here. Rideshare uses a custom script.
 

--- a/db/README.md
+++ b/db/README.md
@@ -1,11 +1,11 @@
 # Database Setup
 
 ## PostgreSQL Version
-Make sure you're running PostgreSQL 16 or newer.
+Make sure you're running PostgreSQL 18 or newer.
 
 We recommend Postgres.app, however Homebrew is popular. Make sure you've used this formula:
 
-<https://formulae.brew.sh/formula/postgresql@16>
+<https://formulae.brew.sh/formula/postgresql@18>
 
 ## Fake data
 Fake data generated from Ruby, using the Faker gem, may be generated using the following commands.

--- a/db/setup.sh
+++ b/db/setup.sh
@@ -13,7 +13,7 @@
 # Later, you'll create the special password file ~/.pgpass, and
 # place your generated password in it.
 #
-# COMPATIBILITY: Requires PostgreSQL 16+
+# COMPATIBILITY: Requires PostgreSQL 18+
 # ENV VARS: [DB_URL, RIDESHARE_DB_PASSWORD]
 
 # Make sure password is set


### PR DESCRIPTION
The Docker setup (docker-compose.yml, Dockerfile, docker/run_db_*.sh, .circleci/config.yml) already targets Postgres 18, and db/structure.sql sets transaction_timeout, which was introduced in Postgres 17. The docs and db/setup.sh still claimed 16+, which cannot load the schema.